### PR TITLE
NEW: Removed old tests

### DIFF
--- a/tests/test_month_delta.py
+++ b/tests/test_month_delta.py
@@ -44,5 +44,4 @@ def test_month_delta_hypothesis(start_date: date, end_date: date) -> None:
             if end_date > start_date:
                 break
             expected -= 1
-
     assert result == expected

--- a/tests/test_month_delta.py
+++ b/tests/test_month_delta.py
@@ -31,8 +31,6 @@ def test_month_delta_hypothesis(start_date: date, end_date: date) -> None:
         "result"
     ].item()
 
-    print(result)
-
     expected = 0
     if start_date <= end_date:
         while True:
@@ -48,6 +46,3 @@ def test_month_delta_hypothesis(start_date: date, end_date: date) -> None:
             expected -= 1
 
     assert result == expected
-
-
-test_month_delta_hypothesis()

--- a/tests/test_month_delta.py
+++ b/tests/test_month_delta.py
@@ -1,83 +1,11 @@
-import polars as pl
-import polars_xdt as xdt
 from datetime import date
+
+import polars as pl
 from dateutil.relativedelta import relativedelta
+from hypothesis import example, given
+from hypothesis import strategies as st
 
-from hypothesis import given, strategies as st, assume
-
-
-def test_month_delta():
-    df = pl.DataFrame(
-        {
-            "start_date": [
-                date(2024, 1, 1),
-                date(2024, 1, 1),
-                date(2023, 9, 1),
-                date(2023, 1, 4),
-                date(2022, 6, 4),
-                date(2023, 1, 1),
-                date(2023, 1, 1),
-                date(2022, 2, 1),
-                date(2022, 2, 1),
-                date(2024, 3, 1),
-                date(2024, 3, 31),
-                date(2022, 2, 28),
-                date(2023, 1, 31),
-                date(2019, 12, 31),
-                date(2024, 1, 31),
-                date(1970, 1, 2),
-            ],
-            "end_date": [
-                date(2024, 1, 4),
-                date(2024, 1, 31),
-                date(2023, 11, 1),
-                date(2022, 1, 4),
-                date(2022, 1, 4),
-                date(2022, 12, 31),
-                date(2021, 12, 31),
-                date(2022, 3, 1),
-                date(2023, 3, 1),
-                date(2023, 2, 28),
-                date(2023, 2, 28),
-                date(2023, 1, 31),
-                date(2022, 2, 28),
-                date(2023, 1, 1),
-                date(2024, 4, 30),
-                date(1971, 1, 1),
-            ],
-        },
-    )
-
-    assert_month_diff = [
-        0,  # 2024-01-01 to 2024-01-04
-        0,  # 2024-01-01 to 2024-01-31
-        2,  # 2023-09-01 to 2023-11-01
-        -12,  # 2023-01-04 to 2022-01-04
-        -5,  # 2022-06-04 to 2022-01-04
-        0,  # 2023-01-01 to 2022-12-31
-        -12,  # 2023-01-01 to 2021-12-31
-        1,  # 2022-02-01 to 2022-03-01
-        13,  # 2022-02-01 to 2023-03-01
-        -12,  # 2024-03-01 to 2023-02-28
-        -13,  # 2024-03-31 to 2023-02-28
-        11,  # 2022-02-28 to 2023-01-31
-        -11,  # 2023-01-31 to 2022-02-28
-        36,  # 2019-12-31 to 2023-01-01
-        3,  # 2024-01-31 to 2024-04-30
-        11,  # 1970-01-02 to 1971-01-01
-    ]
-    df = df.with_columns(
-        # For easier visual debugging purposes
-        pl.Series(name="assert_month_delta", values=assert_month_diff),
-        month_delta=xdt.month_delta("start_date", "end_date"),
-    )
-    # pl.Config.set_tbl_rows(50)
-    # print(df)
-    month_diff_list = df.get_column("month_delta").to_list()
-    assert assert_month_diff == month_diff_list, (
-        "The month difference list did not match the expected values.\n"
-        "Please check the function: 'month_diff.rs' for discrepancies."
-    )
+import polars_xdt as xdt
 
 
 @given(
@@ -86,6 +14,12 @@ def test_month_delta():
     ),
     end_date=st.dates(min_value=date(1960, 1, 1), max_value=date(2024, 12, 31)),
 )
+@example(start_date=date(2022, 2, 28), end_date=date(2024, 2, 29))  # Leap year
+@example(start_date=date(2024, 1, 1), end_date=date(2024, 1, 31))  # Same month
+@example(start_date=date(1973, 1, 1), end_date=date(1973, 1, 1))  # Same date
+@example(start_date=date(2019, 12, 31), end_date=date(2020, 1, 1))  # Border
+@example(start_date=date(2018, 12, 1), end_date=date(2020, 1, 1))  # End of year
+@example(start_date=date(2022, 12, 1), end_date=date(2020, 1, 1))  # Negative
 def test_month_delta_hypothesis(start_date: date, end_date: date) -> None:
     df = pl.DataFrame(
         {
@@ -96,6 +30,8 @@ def test_month_delta_hypothesis(start_date: date, end_date: date) -> None:
     result = df.select(result=xdt.month_delta("start_date", "end_date"))[
         "result"
     ].item()
+
+    print(result)
 
     expected = 0
     if start_date <= end_date:
@@ -112,3 +48,6 @@ def test_month_delta_hypothesis(start_date: date, end_date: date) -> None:
             expected -= 1
 
     assert result == expected
+
+
+test_month_delta_hypothesis()


### PR DESCRIPTION
`example` should cover majority of specific case scenarios that might of been skipped by `given` and that are present in the old test. It is designed as just in case scenario. 

Code:
```py
@given(
    start_date=st.dates(
        min_value=date(1960, 1, 1), max_value=date(2024, 12, 31)
    ),
    end_date=st.dates(min_value=date(1960, 1, 1), max_value=date(2024, 12, 31)),
)
@example(start_date=date(2022, 2, 28), end_date=date(2024, 2, 29))  # Leap year
@example(start_date=date(2024, 1, 1), end_date=date(2024, 1, 31))  # Same month
@example(start_date=date(1973, 1, 1), end_date=date(1973, 1, 1))  # Same date
@example(start_date=date(2019, 12, 31), end_date=date(2020, 1, 1))  # Border
@example(start_date=date(2018, 12, 1), end_date=date(2020, 1, 1))  # End of year
@example(start_date=date(2022, 12, 1), end_date=date(2020, 1, 1))  # Negative
```
`example` are the first tests, the total number of tests are 106 (100 `given` and 6 `example`)
|start_date|end_date|month_delta|
| -------- | -------- | ---- |
| 28/02/22 | 29/02/24 | 24   |
| 01/01/24 | 31/01/24 | 0    |
| 01/01/73 | 01/01/73 | 0    |
| 31/12/19 | 01/01/20 | 0    |
| 01/12/18 | 01/01/20 | 13   |
| 01/12/22 | 01/01/20 | \-35 |
| 01/01/00 | 01/01/00 | 0    |
| 01/01/67 | 01/01/00 | 396  |
| 15/11/67 | 17/04/86 | 221  |
