### PR TITLE
Add robustness to leading `null` values in series in 'ewma_by_time'.

### DIFF
--- a/polars_xdt/functions.py
+++ b/polars_xdt/functions.py
@@ -909,7 +909,6 @@ def ewma_by_time(
     *,
     times: IntoExpr,
     half_life: timedelta,
-    ignore_nulls: bool = True
 ) -> pl.Expr:
     r"""
     Calculate time-based exponentially weighted moving average.
@@ -962,24 +961,7 @@ def ewma_by_time(
     ... )
     >>> df.with_columns(
     ...     ewma=xdt.ewma_by_time(
-    ...         "values", times="times", half_life=timedelta(days=4),
-    ...     ),
-    ... )
-    shape: (5, 3)
-    ┌────────┬────────────┬──────────┐
-    │ values ┆ times      ┆ ewma     │
-    │ ---    ┆ ---        ┆ ---      │
-    │ i64    ┆ date       ┆ f64      │
-    ╞════════╪════════════╪══════════╡
-    │ 0      ┆ 2020-01-01 ┆ 0.0      │
-    │ 1      ┆ 2020-01-03 ┆ 0.292893 │
-    │ 2      ┆ 2020-01-10 ┆ 1.492474 │
-    │ null   ┆ 2020-01-15 ┆ 1.492474 │
-    │ 4      ┆ 2020-01-17 ┆ 3.254508 │
-    └────────┴────────────┴──────────┘
-    >>> df.with_columns(
-    ...     ewma=xdt.ewma_by_time(
-    ...         "values", times="times", half_life=timedelta(days=4), ignore_nulls=False
+    ...         "values", times="times", half_life=timedelta(days=4)
     ...     ),
     ... )
     shape: (5, 3)
@@ -1005,5 +987,5 @@ def ewma_by_time(
         symbol="ewma_by_time",
         is_elementwise=False,
         args=[values, times],
-        kwargs={"half_life": half_life_us, "ignore_nulls": ignore_nulls},
+        kwargs={"half_life": half_life_us},
     )

--- a/polars_xdt/functions.py
+++ b/polars_xdt/functions.py
@@ -934,8 +934,6 @@ def ewma_by_time(
         Times corresponding to `values`. Should be ``DateTime`` or ``Date``.
     half_life
         Unit over which observation decays to half its value.
-    ignore_nulls
-        Ignore missing values when calculating weights.
 
     Returns
     -------

--- a/polars_xdt/functions.py
+++ b/polars_xdt/functions.py
@@ -909,6 +909,7 @@ def ewma_by_time(
     *,
     times: IntoExpr,
     half_life: timedelta,
+    ignore_nulls: bool = True
 ) -> pl.Expr:
     r"""
     Calculate time-based exponentially weighted moving average.
@@ -934,6 +935,8 @@ def ewma_by_time(
         Times corresponding to `values`. Should be ``DateTime`` or ``Date``.
     half_life
         Unit over which observation decays to half its value.
+    ignore_nulls
+        Ignore missing values when calculating weights.
 
     Returns
     -------
@@ -985,5 +988,5 @@ def ewma_by_time(
         symbol="ewma_by_time",
         is_elementwise=False,
         args=[values, times],
-        kwargs={"half_life": half_life_us},
+        kwargs={"half_life": half_life_us, "ignore_nulls": ignore_nulls},
     )

--- a/polars_xdt/functions.py
+++ b/polars_xdt/functions.py
@@ -962,7 +962,24 @@ def ewma_by_time(
     ... )
     >>> df.with_columns(
     ...     ewma=xdt.ewma_by_time(
-    ...         "values", times="times", half_life=timedelta(days=4)
+    ...         "values", times="times", half_life=timedelta(days=4),
+    ...     ),
+    ... )
+    shape: (5, 3)
+    ┌────────┬────────────┬──────────┐
+    │ values ┆ times      ┆ ewma     │
+    │ ---    ┆ ---        ┆ ---      │
+    │ i64    ┆ date       ┆ f64      │
+    ╞════════╪════════════╪══════════╡
+    │ 0      ┆ 2020-01-01 ┆ 0.0      │
+    │ 1      ┆ 2020-01-03 ┆ 0.292893 │
+    │ 2      ┆ 2020-01-10 ┆ 1.492474 │
+    │ null   ┆ 2020-01-15 ┆ 1.492474 │
+    │ 4      ┆ 2020-01-17 ┆ 3.254508 │
+    └────────┴────────────┴──────────┘
+    >>> df.with_columns(
+    ...     ewma=xdt.ewma_by_time(
+    ...         "values", times="times", half_life=timedelta(days=4), ignore_nulls=False
     ...     ),
     ... )
     shape: (5, 3)

--- a/src/ewma_by_time.rs
+++ b/src/ewma_by_time.rs
@@ -5,8 +5,7 @@ pub(crate) fn impl_ewma_by_time_float(
     times: &Int64Chunked,
     values: &Float64Chunked,
     half_life: i64,
-    time_unit: TimeUnit,
-    ignore_nulls: bool
+    time_unit: TimeUnit
 ) -> Float64Chunked {
     let mut out = Vec::with_capacity(times.len());
     if values.is_empty() {
@@ -52,13 +51,6 @@ pub(crate) fn impl_ewma_by_time_float(
                     prev_result = result;
                     out.push(Some(result));
                 },
-                (_, None) => {
-                    if ignore_nulls {
-                        out.push(Some(prev_result));
-                    } else {
-                        out.push(None);
-                    }
-                },
                 _ => out.push(None),
             }
         });
@@ -71,23 +63,22 @@ pub(crate) fn impl_ewma_by_time(
     values: &Series,
     half_life: i64,
     time_unit: TimeUnit,
-    ignore_nulls: bool
 ) -> Series {
     match values.dtype() {
         DataType::Float64 => {
             let values = values.f64().unwrap();
-            impl_ewma_by_time_float(times, values, half_life, time_unit, ignore_nulls).into_series()
+            impl_ewma_by_time_float(times, values, half_life, time_unit).into_series()
         }
         DataType::Int64 | DataType::Int32 => {
             let values = values.cast(&DataType::Float64).unwrap();
             let values = values.f64().unwrap();
-            impl_ewma_by_time_float(times, values, half_life, time_unit, ignore_nulls).into_series()
+            impl_ewma_by_time_float(times, values, half_life, time_unit).into_series()
         }
         DataType::Float32 => {
             // todo: preserve Float32 in this case
             let values = values.cast(&DataType::Float64).unwrap();
             let values = values.f64().unwrap();
-            impl_ewma_by_time_float(times, values, half_life, time_unit, ignore_nulls).into_series()
+            impl_ewma_by_time_float(times, values, half_life, time_unit).into_series()
         }
         dt => panic!("Expected values to be signed numeric, got {:?}", dt),
     }

--- a/src/ewma_by_time.rs
+++ b/src/ewma_by_time.rs
@@ -21,16 +21,16 @@ pub(crate) fn impl_ewma_by_time_float(
     let mut skip_rows: usize = 0;
     let mut prev_time: i64 = 0;
     let mut prev_result: f64 = 0.;
-    for (idx, value) in values.iter().enumerate() {
-        match value {
-            Some(value) => {
-                prev_time = times.get(idx).unwrap();
+    for (idx, (value, time)) in values.iter().zip(times.iter()).enumerate() {
+        match (time, value) {
+            (Some(time), Some(value)) => {
+                prev_time = time;
                 prev_result = value;
                 out.push(Some(prev_result));
                 skip_rows = idx + 1;
                 break;
             },
-            None => {
+            _ => {
                 out.push(None);
             }
         };

--- a/src/expressions.rs
+++ b/src/expressions.rs
@@ -178,8 +178,7 @@ fn arg_previous_greater(inputs: &[Series]) -> PolarsResult<Series> {
 
 #[derive(Deserialize)]
 struct EwmTimeKwargs {
-    half_life: i64,
-    ignore_nulls: bool
+    half_life: i64
 }
 
 #[polars_expr(output_type=Float64)]
@@ -189,7 +188,7 @@ fn ewma_by_time(inputs: &[Series], kwargs: EwmTimeKwargs) -> PolarsResult<Series
         DataType::Datetime(_, _) => {
             let time = &inputs[1].datetime().unwrap();
             Ok(
-                impl_ewma_by_time(&time.0, values, kwargs.half_life, time.time_unit(), kwargs.ignore_nulls)
+                impl_ewma_by_time(&time.0, values, kwargs.half_life, time.time_unit())
                     .into_series(),
             )
         }
@@ -197,7 +196,7 @@ fn ewma_by_time(inputs: &[Series], kwargs: EwmTimeKwargs) -> PolarsResult<Series
             let binding = &inputs[1].cast(&DataType::Datetime(TimeUnit::Milliseconds, None))?;
             let time = binding.datetime().unwrap();
             Ok(
-                impl_ewma_by_time(&time.0, values, kwargs.half_life, time.time_unit(), kwargs.ignore_nulls)
+                impl_ewma_by_time(&time.0, values, kwargs.half_life, time.time_unit())
                     .into_series(),
             )
         }

--- a/src/expressions.rs
+++ b/src/expressions.rs
@@ -179,6 +179,7 @@ fn arg_previous_greater(inputs: &[Series]) -> PolarsResult<Series> {
 #[derive(Deserialize)]
 struct EwmTimeKwargs {
     half_life: i64,
+    ignore_nulls: bool
 }
 
 #[polars_expr(output_type=Float64)]
@@ -188,7 +189,7 @@ fn ewma_by_time(inputs: &[Series], kwargs: EwmTimeKwargs) -> PolarsResult<Series
         DataType::Datetime(_, _) => {
             let time = &inputs[1].datetime().unwrap();
             Ok(
-                impl_ewma_by_time(&time.0, values, kwargs.half_life, time.time_unit())
+                impl_ewma_by_time(&time.0, values, kwargs.half_life, time.time_unit(), kwargs.ignore_nulls)
                     .into_series(),
             )
         }
@@ -196,7 +197,7 @@ fn ewma_by_time(inputs: &[Series], kwargs: EwmTimeKwargs) -> PolarsResult<Series
             let binding = &inputs[1].cast(&DataType::Datetime(TimeUnit::Milliseconds, None))?;
             let time = binding.datetime().unwrap();
             Ok(
-                impl_ewma_by_time(&time.0, values, kwargs.half_life, time.time_unit())
+                impl_ewma_by_time(&time.0, values, kwargs.half_life, time.time_unit(), kwargs.ignore_nulls)
                     .into_series(),
             )
         }

--- a/tests/test_ewma_by_time.py
+++ b/tests/test_ewma_by_time.py
@@ -1,6 +1,7 @@
 import polars as pl
 from polars.testing import assert_frame_equal
 import polars_xdt as xdt
+import pytest
 from datetime import datetime, timedelta
 
 
@@ -31,4 +32,51 @@ def test_ewma_by_time():
             ]
         }
     )
+
+    assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize("ignore_nulls", [
+    True,
+    False
+])
+def test_ewma_with_nan(ignore_nulls):
+    n = 6
+
+    df = pl.DataFrame({
+        "values": list(range(n)),
+        "times": [datetime(2020, 1, 1) + timedelta(days=i) for i in range(n)]
+    })
+
+    result = df.select(xdt.ewma_by_time(
+        pl.when(pl.col("values") > n//2).then(float("NaN")).otherwise(pl.col("values")), times="times", half_life=timedelta(days=1), ignore_nulls=ignore_nulls
+    ))
+    
+    if ignore_nulls:
+        expected = pl.DataFrame(
+            {
+                "literal": [
+                    0.0,
+                    0.5,
+                    1.25,
+                    2.125,
+                    2.125,
+                    2.125,
+                ]
+            }
+        )
+    else:
+        expected = pl.DataFrame(
+            {
+                "literal": [
+                    0.0,
+                    0.5,
+                    1.25,
+                    2.125,
+                    float("NaN"),
+                    float("NaN")
+                ]
+            }
+        )
+        
     assert_frame_equal(result, expected)

--- a/tests/test_ewma_by_time.py
+++ b/tests/test_ewma_by_time.py
@@ -8,107 +8,41 @@ import os
 
 os.environ["POLARS_VERBOSE"] = "1"
 
-def test_ewma_by_time():
+@pytest.mark.parametrize("start_null", [True, False])
+def test_ewma_by_time(start_null):
+    if start_null:
+        values = [None]
+        times = [datetime(2020, 1, 1)]
+    else:
+        values = []
+        times = []
+        
     df = pl.DataFrame(
         {
-            "values": [0.0, 1, 2, None, 4],
-            "times": [
-                datetime(2020, 1, 1),
-                datetime(2020, 1, 3),
-                datetime(2020, 1, 10),
-                datetime(2020, 1, 15),
-                datetime(2020, 1, 17),
+            "values": values + [0.0, 1., 2., None, 4.],
+            "times": times + [
+                datetime(2020, 1, 2),
+                datetime(2020, 1, 4),
+                datetime(2020, 1, 11),
+                datetime(2020, 1, 16),
+                datetime(2020, 1, 18),
             ],
         }
     )
     result = df.select(
-        xdt.ewma_by_time("values", times="times", half_life=timedelta(days=4), ignore_nulls=False),
+        xdt.ewma_by_time("values", times="times", half_life=timedelta(days=2)),
     )
+        
     expected = pl.DataFrame(
         {
-            "values": [
+            "values": values + [
                 0.0,
-                0.2928932188134524,
-                1.4924741174358913,
+                0.5,
+                1.8674174785275222,
                 None,
-                3.2545080948503213,
+                3.811504554703363,
             ]
         }
     )
 
-    assert_frame_equal(result, expected)
-
-
-@pytest.mark.parametrize("ignore_nulls", [True, False])
-@pytest.mark.parametrize("start_null", [True, False])
-def test_ewma_with_nan(ignore_nulls, start_null):
-    n = 6
-
-    df = pl.DataFrame({
-        "values": list(range(n)),
-        "times": [datetime(2020, 1, 1) + timedelta(days=i) for i in range(n)]
-    })
-    
-    when = pl.col("values") > n//2
-    
-    if start_null:
-        when = when.or_(pl.col("values") == 0)
-
-    result = df.select(xdt.ewma_by_time(
-        pl.when(when).then(None).otherwise(pl.col("values")), times="times", half_life=timedelta(days=1), ignore_nulls=ignore_nulls
-    ))
-    
-    if ignore_nulls & start_null:
-            expected = pl.DataFrame(
-                {
-                    "literal": [
-                        None,
-                        1,
-                        1.5,
-                        2.25,
-                        2.25,
-                        2.25,
-                    ]
-                }
-            )
-    elif ignore_nulls & ~start_null:
-        expected = pl.DataFrame(
-            {
-                "literal": [
-                    0.,
-                    0.5,
-                    1.25,
-                    2.125,
-                    2.125,
-                    2.125,
-                ]
-            }
-        )
-    elif ~ignore_nulls & start_null:
-        expected = pl.DataFrame(
-            {
-                "literal": [
-                    None, 
-                    1,
-                    1.5,
-                    2.25,
-                    None,
-                    None
-                ]
-            }
-        ).with_columns(pl.col("literal").cast(pl.Float64))
-    else:
-        expected = pl.DataFrame(
-            {
-                "literal": [
-                    0.0,
-                    0.5,
-                    1.25,
-                    2.125,
-                    None,
-                    None
-                ]
-            }
-        )
-        
     assert_frame_equal(result, expected)


### PR DESCRIPTION
Following up #71, I've added an `ignore_nulls` flag to 'ewma_by_time' with a default `True` value. The main design choices are as follows:  

1. When the sequence starts with a `NaN`, all values in the EWMA should also be `NaN`, up until the first non-`NaN` index, which should return its own value. 

2. A string of consecutive `NaN` values should all have the same output as proceeding non-`NaN` value, as no additional information has been added to the sequence.


